### PR TITLE
remove map; reduce min-width; fill empty space

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4,7 +4,7 @@ html {
 
 body {
 	width: 100%;
-	min-width: 1900px;
+	min-width: 1200px;
 	font-smooth: auto;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -4,7 +4,7 @@ extends ./layout.jade
 block content
   div.container-fluid(ng-controller='StatsCtrl')
     div.row(ng-cloak)
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.bestblock.text-info
           div.pull-left.icon-full-width
             i.icon-block
@@ -12,7 +12,7 @@ block content
             span.small-title best block
             span.big-details {{'#'}}{{ bestBlock | number}}
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.difficulty.text-orange
           div.pull-left.icon-full-width
             i.icon-hashrate
@@ -20,7 +20,7 @@ block content
             span.small-title avg transactions rate
             span.big-details(ng-bind-html="avgTransactionRate | transactionRateFilter")
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.blocktime(class="{{ lastBlock | timeClass : true }}")
           div.pull-left.icon-full-width
             i.icon-time
@@ -29,7 +29,7 @@ block content
             span.big-details {{ lastBlock | blockTimeFilter }}
             //- span.big-details(time-ago="lastBlock")
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.avgblocktime(class="{{ avgBlockTime | avgTimeClass }}")
           div.pull-left.icon-full-width
             i.icon-gas
@@ -53,17 +53,17 @@ block content
     div.row(ng-cloak)
       div.col-xs-12.stats-boxes(style="padding-top: 0px;")
         div.row.second-row
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes(class="{{ nodesActive | nodesActiveClass : nodesTotal }}")
               i.icon-node
               span.small-title active nodes
               span.small-value {{nodesActive}}/{{nodesTotal}}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-info
               i.icon-gasprice
               span.small-title gas price
               span.small-value {{ bestStats.gasPrice.toString() | gasPriceFilter }}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-info
               i.icon-gasprice
               span.small-title gas limit
@@ -73,7 +73,7 @@ block content
           //-     i.icon-clock
           //-     span.small-title page latency
           //-     span.small-value {{latency}} ms
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.uptime(class="{{ upTimeTotal | upTimeClass : true }}")
               i.icon-bulb
               span.small-title uptime
@@ -81,7 +81,7 @@ block content
           //- div.col-xs-2.stat-holder.box
 
         div.row
-          div.col-xs-8
+          div.col-xs-12
             div.row
               div.col-xs-4.stat-holder.xpull-right
                 div.big-info.chart.xdouble-chart
@@ -139,9 +139,9 @@ block content
                   histogram.big-details.d3-blockpropagation(data="blockPropagationChart")
 
 
-          div.col-xs-4.stat-holder.map-holder
+          //- div.col-xs-4.stat-holder.map-holder
             //- div.col-xs-12
-            nodemap#mapHolder(data="map")
+            //- nodemap#mapHolder(data="map")
 
     div.row
       div.col-xs-12.stats-boxes


### PR DESCRIPTION
This change removes the map and allows the other cells to fill the full width. It also reduces the min-width of the body from 1900px to 1200px, which is just enough not to cut off the charts and wrap text.

![screenshot from 2018-03-14 13-18-10](https://user-images.githubusercontent.com/1194128/37422848-398f71ca-278a-11e8-84ff-a3e3561e37eb.png)

Fixes #12. Towards #11 (charts still fixed width).