### PR TITLE
limit max history to chart size; fill charts with 0s while building history

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var d3 = require('d3');
 
-var MAX_HISTORY = 100;
+var MAX_HISTORY = 40;
 
 var MAX_PEER_PROPAGATION = 40;
 var MIN_PROPAGATION_RANGE = 0;
@@ -576,6 +576,19 @@ History.prototype.getCharts = function () {
 				};
 			})
 			.value();
+		if (chartHistory.length < MAX_BINS) {
+			chartHistory.unshift(...Array(MAX_BINS-chartHistory.length).fill({
+                height: 0,
+                blocktime: 0,
+                difficulty: 0,
+                uncles: 0,
+                transactions: 0,
+                transactionrate: 0,
+                gasSpending: 0,
+                gasLimit: 0,
+                miner: 0
+            }))
+		}
 
 		this._callback(null, {
 			height: _.pluck(chartHistory, 'height'),


### PR DESCRIPTION
This PR limits the size of the history to what we display, which 'fixes' the delay we've been seeing. It also fills the charts with 0s while the history is building, so we get partial charts instead of empty charts (or '2's or whatever it was).