### PR TITLE
restore map; upgrade geoip-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "d3": "3.5.6",
     "debug": "2.2.0",
     "express": "4.13.3",
-    "geoip-lite": "1.1.6",
+    "geoip-lite": "1.2.2",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -81,7 +81,7 @@ block content
           //- div.col-xs-2.stat-holder.box
 
         div.row
-          div.col-xs-12
+          div.col-xs-8
             div.row
               div.col-xs-4.stat-holder.xpull-right
                 div.big-info.chart.text-info
@@ -140,9 +140,9 @@ block content
                   histogram.big-details.d3-blockpropagation(data="blockPropagationChart")
 
 
-          //- div.col-xs-4.stat-holder.map-holder
-            //- div.col-xs-12
-            //- nodemap#mapHolder(data="map")
+          div.col-xs-4.stat-holder.map-holder
+            div.col-xs-12
+            nodemap#mapHolder(data="map")
 
     div.row
       div.col-xs-12.stats-boxes

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -151,7 +151,7 @@ block content
             div.active-nodes.text-warning
               i.icon-warning-o
               span.small-title ATTENTION!
-              span.small-value This page does not represent the entire state of the GoChain network - listing a node on this page is a voluntary process.
+              span.small-value This does not represent the entire GoChain network - only authorized signer and proxy nodes. Information is real-time and may not be 100% accurate.
           //- div.col-xs-12.stat-holder.box
           //-   div.active-nodes.text-danger
           //-     i.icon-hashrate


### PR DESCRIPTION
This PR restores the map, and upgrades the `geoip-lite` package to get non-null geo results (though still maybe not totally accurate). Fixes #23. Currently deployed on devnet:
![screenshot from 2018-07-02 10-23-10](https://user-images.githubusercontent.com/1194128/42172551-f314ce6c-7de1-11e8-8f50-cc6de7b3d5bf.png)

How concerned about accuracy are we? That dot in Texas is a DO droplet in `NYC3` and Vancouver is `SFO2`, so this may not be a reliable method.