### PR TITLE
WIP: Ensure consistent history.

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -13,6 +13,7 @@ var MAX_BINS = 40;
 
 var History = function History(data) {
 	this._items = [];
+	this._currentBlockNumber = 0;
 	this._callback = null;
 }
 
@@ -210,6 +211,73 @@ History.prototype._save = function (block) {
 	if (this._items.length > MAX_HISTORY) {
 		this._items.pop();
 	}
+
+	// Find highest difficulty block.
+	var highest = this.highestDifficultyBlock()
+	this._currentBlockNumber = highest !== null ? highest.height : 0;
+
+	// Update the index to point to the current fork.
+	this._updateCurrentFork()
+}
+
+History.prototype.highestDifficultyBlock = function () {
+	var highest = null;
+	for (var i = 0; i < this._items.length; i++) {
+		var item = this._items[i];
+		for (var j = 0; j < item.forks.length; j++) {
+			if (highest === null || item.forks[j].totalDifficulty > highest.totalDifficulty) {
+				highest = item.forks[j]
+			}
+		}
+	}
+	return highest
+}
+
+History.prototype._updateCurrentFork = function () {
+	var parentHash = null;
+	for (var i = this._items.length-1; i >= 0; i--) {
+		var item = this._items[i];
+
+		// Skip if this is after the current block.
+		if (item.height > this._currentBlockNumber) {
+			continue
+		}
+
+		// If we haven't found the initial current block, find it by difficulty.
+		if (parentHash === null) {
+			parentHash = this._setItemForkByTotalDifficulty(item)
+			continue
+		}
+
+		// If we've found a previous parent hash then set fork by that hash.
+		parentHash = this._setItemForkByParentHash(item, parentHash)
+	}
+}
+
+// Sets the fork index for the fork with a matching parent hash.
+// Returns the fork's hash.
+History.prototype._setItemForkByParentHash = function (item, parentHash) {
+	var hash = "";
+	for (var i = 0; i < item.forks.length; i++) {
+		if (item.forks[i].parentHash === parentHash) {
+			item.forkIndex = i;
+			hash = item.hash
+			break;
+		}
+	}
+	return hash
+}
+
+// Sets the fork index for the fork with the highest total difficulty.
+// Returns the fork's hash.
+History.prototype._setItemForkByTotalDifficulty = function (item) {
+	var max = 0;
+	for (var i = 0; i < item.forks.length; i++) {
+		if (item.forks[i].totalDifficulty > max) {
+			item.forkIndex = i;
+		}
+	}
+	return item.forks[item.forkIndex].hash
 }
 
 History.prototype.clean = function (max) {


### PR DESCRIPTION
This commit changes the netstats history `items` to choose a chain based on the highest total difficulty block and then subsequent items are chosen based on the `parentHash`.