### PR TITLE
fix trusted.json file usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /tmp/netstats /usr/local/bin/netstats
 
+WORKDIR /netstats
+
 # Pull MaxMind city database.
 RUN wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
 	&& tar zxvf GeoLite2-City.tar.gz \

--- a/cmd/netstats/main.go
+++ b/cmd/netstats/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -82,11 +83,16 @@ func readTrustedFile(path string) (map[string]*netstats.Geo, error) {
 
 	geoByIP := make(map[string]*netstats.Geo)
 	if buf, err := ioutil.ReadFile(path); os.IsNotExist(err) && useDefault {
+		log.Printf("No default trusted file found: %s\n", path)
 		return geoByIP, nil
 	} else if err != nil {
 		return nil, err
-	} else if err := json.Unmarshal(buf, geoByIP); err != nil {
+	} else if err := json.Unmarshal(buf, &geoByIP); err != nil {
 		return nil, err
+	}
+	log.Println("Loaded trusted nodes:")
+	for ip, geo := range geoByIP {
+		fmt.Printf("  %q: %#v\n", ip, geo)
 	}
 	return geoByIP, nil
 }

--- a/db.go
+++ b/db.go
@@ -137,10 +137,12 @@ func (db *DB) CreateNodeIfNotExists(ctx context.Context, node *Node) error {
 		if geo := db.GeoByIP[node.Info.IP]; geo != nil {
 			node.Trusted = true
 			node.Geo = geo.Clone()
+			log.Printf("Node %q is a trusted node: %#v", node.Info.IP, node.Geo)
 		} else if geo, err := db.GeoService.GeoByIP(context.Background(), node.Info.IP); err != nil {
-			log.Printf("cannot find geolocation by ip: %s", node.Info.IP)
+			log.Printf("Cannot find geolocation by ip: %s", node.Info.IP)
 		} else if geo != nil {
 			node.Geo = geo.Clone()
+			log.Printf("Node %q is an unknown node: %#v", node.Info.IP, node.Geo)
 		}
 	}
 


### PR DESCRIPTION
Fixes #40 

Now we log about whether the `trusted.json` file was found, dump its contents, and as each node connects we log if it is trusted or unknown and the geo data being used.

```sh
2019/02/26 21:24:27 Loaded trusted nodes:
  "150.109.13.11": &netstats.Geo{City:"Singapore", Country:"SG", LL:[]float64{1.3521, 103.8198}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "206.189.65.13": &netstats.Geo{City:"San Francisco", Country:"US", LL:[]float64{37.7749, -122.4194}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "159.89.188.156": &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "159.65.188.200": &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "159.65.180.208": &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.200.134.197": &netstats.Geo{City:"Mumbai", Country:"India", LL:[]float64{19.076, 72.8777}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.230.123.57": &netstats.Geo{City:"The Dalles", Country:"Oregon", LL:[]float64{45.5946, -121.1787}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.200.172.87": &netstats.Geo{City:"Mumbai", Country:"India", LL:[]float64{19.076, 72.8777}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.204.146.204": &netstats.Geo{City:"Amsterdam", Country:"NL", LL:[]float64{52.3702, 4.8952}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "206.189.65.50": &netstats.Geo{City:"San Francisco", Country:"US", LL:[]float64{37.7749, -122.4194}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "159.89.180.144": &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "54.36.127.14": &netstats.Geo{City:"Paris", Country:"FR", LL:[]float64{48.8566, 2.3522}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "54.36.127.19": &netstats.Geo{City:"Paris", Country:"FR", LL:[]float64{48.8566, 2.3522}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.228.188.186": &netstats.Geo{City:"Hamina", Country:"Finland", LL:[]float64{60.5693, 27.1878}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "34.244.147.65": &netstats.Geo{City:"Dublin", Country:"Ireland", LL:[]float64{53.3498, -6.2603}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "35.199.125.0": &netstats.Geo{City:"Sao Paulo", Country:"Brazil", LL:[]float64{-23.5505, -46.6333}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
  "159.65.77.135": &netstats.Geo{City:"San Francisco", Country:"US", LL:[]float64{37.7749, -122.4194}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
Listening on http://localhost:80
2019/02/26 21:24:30 Node "159.65.180.208" is a trusted node: &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "159.89.188.156" is a trusted node: &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "159.89.180.144" is a trusted node: &netstats.Geo{City:"New York", Country:"US", LL:[]float64{40.7128, -74.006}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "159.203.59.117" is an unknown node: &netstats.Geo{City:"Toronto", Country:"CA", LL:[]float64{43.6547, -79.3623}, Metro:0, Range:[]int{0, 0}, Region:"Ontario", Zip:0}
2019/02/26 21:24:30 Node "52.15.143.188" is an unknown node: &netstats.Geo{City:"Columbus", Country:"US", LL:[]float64{39.9653, -83.0235}, Metro:535, Range:[]int{0, 0}, Region:"Ohio", Zip:43215}
2019/02/26 21:24:30 Node "24.51.113.171" is an unknown node: &netstats.Geo{City:"Nassau", Country:"BS", LL:[]float64{25.0833, -77.35}, Metro:0, Range:[]int{0, 0}, Region:"New Providence District", Zip:0}
2019/02/26 21:24:30 Node "54.36.127.19" is a trusted node: &netstats.Geo{City:"Paris", Country:"FR", LL:[]float64{48.8566, 2.3522}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "5.104.228.29" is an unknown node: &netstats.Geo{City:"", Country:"NL", LL:[]float64{52.3824, 4.8995}, Metro:0, Range:[]int{0, 0}, Region:"", Zip:0}
2019/02/26 21:24:30 Node "109.237.208.189" is an unknown node: &netstats.Geo{City:"", Country:"NL", LL:[]float64{52.3824, 4.8995}, Metro:0, Range:[]int{0, 0}, Region:"", Zip:0}
2019/02/26 21:24:30 Node "35.204.146.204" is a trusted node: &netstats.Geo{City:"Amsterdam", Country:"NL", LL:[]float64{52.3702, 4.8952}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "34.244.147.65" is a trusted node: &netstats.Geo{City:"Dublin", Country:"Ireland", LL:[]float64{53.3498, -6.2603}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "35.230.123.57" is a trusted node: &netstats.Geo{City:"The Dalles", Country:"Oregon", LL:[]float64{45.5946, -121.1787}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "159.65.77.135" is a trusted node: &netstats.Geo{City:"San Francisco", Country:"US", LL:[]float64{37.7749, -122.4194}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "206.189.65.13" is a trusted node: &netstats.Geo{City:"San Francisco", Country:"US", LL:[]float64{37.7749, -122.4194}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "35.228.188.186" is a trusted node: &netstats.Geo{City:"Hamina", Country:"Finland", LL:[]float64{60.5693, 27.1878}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "35.199.125.0" is a trusted node: &netstats.Geo{City:"Sao Paulo", Country:"Brazil", LL:[]float64{-23.5505, -46.6333}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:30 Node "13.112.52.91" is an unknown node: &netstats.Geo{City:"Tokyo", Country:"JP", LL:[]float64{35.6882, 139.7532}, Metro:0, Range:[]int{0, 0}, Region:"Tokyo", Zip:0}
2019/02/26 21:24:30 Node "150.109.13.11" is a trusted node: &netstats.Geo{City:"Singapore", Country:"SG", LL:[]float64{1.3521, 103.8198}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
2019/02/26 21:24:31 Node "13.237.126.80" is an unknown node: &netstats.Geo{City:"Sydney", Country:"AU", LL:[]float64{-33.8612, 151.1982}, Metro:0, Range:[]int{0, 0}, Region:"New South Wales", Zip:1001}
2019/02/26 21:24:31 Node "35.200.172.87" is a trusted node: &netstats.Geo{City:"Mumbai", Country:"India", LL:[]float64{19.076, 72.8777}, Metro:0, Range:[]int(nil), Region:"", Zip:0}
```