### PR TITLE
fix trusted ids

### DIFF
--- a/db.go
+++ b/db.go
@@ -133,6 +133,7 @@ func (db *DB) Blocks(ctx context.Context) ([]*Block, error) {
 }
 
 // CreateNodeIfNotExists adds the node to the database if it is not already registered.
+// If the node is trusted, the ID may be updated.
 func (db *DB) CreateNodeIfNotExists(ctx context.Context, node *Node) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()


### PR DESCRIPTION
This PR fixes #67, which didn't use the trusted ID everywhere. Now the original id is changed right away and the old one discarded.